### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ send = []
 serialize = ["serde", "erased-serde", "serde-value"]
 macros = ["mlua_derive/macros"]
 unstable = []
-abort = []
+panic-safety = []
+default = ["panic-safety"]
 
 [dependencies]
 mlua_derive = { version = "=0.9.0", optional = true, path = "mlua_derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,9 @@ send = []
 serialize = ["serde", "erased-serde", "serde-value"]
 macros = ["mlua_derive/macros"]
 unstable = []
-panic-safety = []
-default = ["panic-safety"]
+panic-safety = ["std"]
+std = ["no-std-compat2/std"]
+default = ["std"]
 
 [dependencies]
 mlua_derive = { version = "=0.9.0", optional = true, path = "mlua_derive" }
@@ -56,6 +57,7 @@ serde = { version = "1.0", optional = true }
 erased-serde = { version = "0.3", optional = true }
 serde-value = { version = "0.7", optional = true }
 parking_lot = { version = "0.12", optional = true }
+no-std-compat2 = { version = "0.4.5", features = ["alloc", "compat_hash"] }
 
 ffi = { package = "mlua-sys", version = "0.3.2", path = "mlua-sys" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ send = []
 serialize = ["serde", "erased-serde", "serde-value"]
 macros = ["mlua_derive/macros"]
 unstable = []
+abort = []
 
 [dependencies]
 mlua_derive = { version = "=0.9.0", optional = true, path = "mlua_derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,15 @@ serialize = ["serde", "erased-serde", "serde-value"]
 macros = ["mlua_derive/macros"]
 unstable = []
 panic-safety = ["std"]
-std = ["no-std-compat2/std"]
+std = ["no-std-compat2/std", "ffi/std", "rustc-hash/std"]
 default = ["std"]
 
 [dependencies]
 mlua_derive = { version = "=0.9.0", optional = true, path = "mlua_derive" }
-bstr = { version = "1.0", features = ["std"], default_features = false }
-once_cell = { version = "1.0" }
-num-traits = { version = "0.2.14" }
-rustc-hash = "1.0"
+bstr = { version = "1.0", features = ["alloc"], default-features = false }
+once_cell = { version = "1.0", features = ["alloc", "critical-section"], default_features = false }
+num-traits = { version = "0.2.14", default-features = false }
+rustc-hash = { version = "1.0", default_features = false }
 futures-util = { version = "0.3", optional = true, default-features = false, features = ["std"] }
 serde = { version = "1.0", optional = true }
 erased-serde = { version = "0.3", optional = true }
@@ -59,7 +59,7 @@ serde-value = { version = "0.7", optional = true }
 parking_lot = { version = "0.12", optional = true }
 no-std-compat2 = { version = "0.4.5", features = ["alloc", "compat_hash"] }
 
-ffi = { package = "mlua-sys", version = "0.3.2", path = "mlua-sys" }
+ffi = { package = "mlua-sys", version = "0.3.2", path = "mlua-sys", default-features = false }
 
 [dev-dependencies]
 rustyline = "12.0"

--- a/mlua-sys/Cargo.toml
+++ b/mlua-sys/Cargo.toml
@@ -35,8 +35,8 @@ std = ["no-std-compat2/std"]
 default = ["std"]
 
 [dependencies]
-libm = "0.2.7"
 no-std-compat2 = { version = "0.4.5", features = ["alloc", "compat_hash"] }
+num-traits = { version = "0.2.16", default-features = false, features = ["libm"] }
 
 [build-dependencies]
 cc = "1.0"

--- a/mlua-sys/Cargo.toml
+++ b/mlua-sys/Cargo.toml
@@ -31,8 +31,12 @@ luau-codegen = ["luau"]
 luau-vector4 = ["luau"]
 vendored = ["lua-src", "luajit-src"]
 module = []
+std = ["no-std-compat2/std"]
+default = ["std"]
 
 [dependencies]
+libm = "0.2.7"
+no-std-compat2 = { version = "0.4.5", features = ["alloc", "compat_hash"] }
 
 [build-dependencies]
 cc = "1.0"

--- a/mlua-sys/src/lib.rs
+++ b/mlua-sys/src/lib.rs
@@ -4,6 +4,9 @@
 #![allow(clippy::missing_safety_doc)]
 #![doc(test(attr(deny(warnings))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![no_std]
+
+extern crate no_std_compat2 as std;
 
 use std::ffi::c_int;
 

--- a/mlua-sys/src/lib.rs
+++ b/mlua-sys/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc(test(attr(deny(warnings))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use std::os::raw::c_int;
+use std::ffi::c_int;
 
 #[cfg(any(feature = "lua54", doc))]
 pub use lua54::*;

--- a/mlua-sys/src/lua51/compat.rs
+++ b/mlua-sys/src/lua51/compat.rs
@@ -10,6 +10,9 @@ use std::ptr;
 use super::lauxlib::*;
 use super::lua::*;
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float; // for f64::abs()
+
 #[inline(always)]
 unsafe fn compat53_reverse(L: *mut lua_State, mut a: c_int, mut b: c_int) {
     while a < b {
@@ -188,7 +191,7 @@ pub unsafe fn lua_isinteger(L: *mut lua_State, idx: c_int) -> c_int {
     if lua_type(L, idx) == LUA_TNUMBER {
         let n = lua_tonumber(L, idx);
         let i = lua_tointeger(L, idx);
-        if libm::fabs(n - i as lua_Number) < lua_Number::EPSILON {
+        if (n - i as lua_Number).abs() < lua_Number::EPSILON {
             return 1;
         }
     }
@@ -214,7 +217,7 @@ pub unsafe fn lua_tointegerx(L: *mut lua_State, i: c_int, isnum: *mut c_int) -> 
     let mut ok = 0;
     let n = lua_tonumberx(L, i, &mut ok);
     let n_int = n as lua_Integer;
-    if ok != 0 && libm::fabs(n - n_int as lua_Number) < lua_Number::EPSILON {
+    if ok != 0 && (n - n_int as lua_Number).abs() < lua_Number::EPSILON {
         if !isnum.is_null() {
             *isnum = 1;
         }

--- a/mlua-sys/src/lua51/compat.rs
+++ b/mlua-sys/src/lua51/compat.rs
@@ -188,7 +188,7 @@ pub unsafe fn lua_isinteger(L: *mut lua_State, idx: c_int) -> c_int {
     if lua_type(L, idx) == LUA_TNUMBER {
         let n = lua_tonumber(L, idx);
         let i = lua_tointeger(L, idx);
-        if (n - i as lua_Number).abs() < lua_Number::EPSILON {
+        if libm::fabs(n - i as lua_Number) < lua_Number::EPSILON {
             return 1;
         }
     }
@@ -214,7 +214,7 @@ pub unsafe fn lua_tointegerx(L: *mut lua_State, i: c_int, isnum: *mut c_int) -> 
     let mut ok = 0;
     let n = lua_tonumberx(L, i, &mut ok);
     let n_int = n as lua_Integer;
-    if ok != 0 && (n - n_int as lua_Number).abs() < lua_Number::EPSILON {
+    if ok != 0 && libm::fabs(n - n_int as lua_Number) < lua_Number::EPSILON {
         if !isnum.is_null() {
             *isnum = 1;
         }

--- a/mlua-sys/src/lua51/compat.rs
+++ b/mlua-sys/src/lua51/compat.rs
@@ -3,8 +3,8 @@
 //! Based on github.com/keplerproject/lua-compat-5.3
 
 use std::convert::TryInto;
+use std::ffi::{c_char, c_int, c_void};
 use std::mem;
-use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
 
 use super::lauxlib::*;

--- a/mlua-sys/src/lua51/lauxlib.rs
+++ b/mlua-sys/src/lua51/lauxlib.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `lauxlib.h`.
 
-use std::os::raw::{c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void};
 use std::ptr;
 
 use super::lua::{self, lua_CFunction, lua_Integer, lua_Number, lua_State};

--- a/mlua-sys/src/lua51/lua.rs
+++ b/mlua-sys/src/lua51/lua.rs
@@ -1,7 +1,7 @@
 //! Contains definitions from `lua.h`.
 
+use std::ffi::{c_char, c_double, c_int, c_void};
 use std::marker::{PhantomData, PhantomPinned};
-use std::os::raw::{c_char, c_double, c_int, c_void};
 use std::ptr;
 
 // Mark for precompiled code (`<esc>Lua`)

--- a/mlua-sys/src/lua51/lualib.rs
+++ b/mlua-sys/src/lua51/lualib.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `lualib.h`.
 
-use std::os::raw::c_int;
+use std::ffi::c_int;
 
 use super::lua::lua_State;
 

--- a/mlua-sys/src/lua52/compat.rs
+++ b/mlua-sys/src/lua52/compat.rs
@@ -52,7 +52,7 @@ pub unsafe fn lua_isinteger(L: *mut lua_State, idx: c_int) -> c_int {
     if lua_type(L, idx) == LUA_TNUMBER {
         let n = lua_tonumber(L, idx);
         let i = lua_tointeger(L, idx);
-        if (n - i as lua_Number).abs() < lua_Number::EPSILON {
+        if libm::fabs(n - i as lua_Number) < lua_Number::EPSILON {
             return 1;
         }
     }
@@ -71,7 +71,7 @@ pub unsafe fn lua_tointegerx(L: *mut lua_State, i: c_int, isnum: *mut c_int) -> 
     let mut ok = 0;
     let n = lua_tonumberx(L, i, &mut ok);
     let n_int = n as lua_Integer;
-    if ok != 0 && (n - n_int as lua_Number).abs() < lua_Number::EPSILON {
+    if ok != 0 && libm::fabs(n - n_int as lua_Number) < lua_Number::EPSILON {
         if !isnum.is_null() {
             *isnum = 1;
         }

--- a/mlua-sys/src/lua52/compat.rs
+++ b/mlua-sys/src/lua52/compat.rs
@@ -3,7 +3,7 @@
 //! Based on github.com/keplerproject/lua-compat-5.3
 
 use std::convert::TryInto;
-use std::os::raw::{c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void};
 use std::ptr;
 
 use super::lauxlib::*;

--- a/mlua-sys/src/lua52/compat.rs
+++ b/mlua-sys/src/lua52/compat.rs
@@ -9,6 +9,9 @@ use std::ptr;
 use super::lauxlib::*;
 use super::lua::*;
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float; // for f64::abs()
+
 #[inline(always)]
 unsafe fn compat53_reverse(L: *mut lua_State, mut a: c_int, mut b: c_int) {
     while a < b {
@@ -52,7 +55,7 @@ pub unsafe fn lua_isinteger(L: *mut lua_State, idx: c_int) -> c_int {
     if lua_type(L, idx) == LUA_TNUMBER {
         let n = lua_tonumber(L, idx);
         let i = lua_tointeger(L, idx);
-        if libm::fabs(n - i as lua_Number) < lua_Number::EPSILON {
+        if (n - i as lua_Number).abs() < lua_Number::EPSILON {
             return 1;
         }
     }
@@ -71,7 +74,7 @@ pub unsafe fn lua_tointegerx(L: *mut lua_State, i: c_int, isnum: *mut c_int) -> 
     let mut ok = 0;
     let n = lua_tonumberx(L, i, &mut ok);
     let n_int = n as lua_Integer;
-    if ok != 0 && libm::fabs(n - n_int as lua_Number) < lua_Number::EPSILON {
+    if ok != 0 && (n - n_int as lua_Number).abs() < lua_Number::EPSILON {
         if !isnum.is_null() {
             *isnum = 1;
         }

--- a/mlua-sys/src/lua52/lauxlib.rs
+++ b/mlua-sys/src/lua52/lauxlib.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `lauxlib.h`.
 
-use std::os::raw::{c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void};
 use std::ptr;
 
 use super::lua::{self, lua_CFunction, lua_Integer, lua_Number, lua_State, lua_Unsigned};

--- a/mlua-sys/src/lua52/lua.rs
+++ b/mlua-sys/src/lua52/lua.rs
@@ -1,7 +1,7 @@
 //! Contains definitions from `lua.h`.
 
+use std::ffi::{c_char, c_double, c_int, c_uchar, c_uint, c_void};
 use std::marker::{PhantomData, PhantomPinned};
-use std::os::raw::{c_char, c_double, c_int, c_uchar, c_uint, c_void};
 use std::ptr;
 
 // Mark for precompiled code (`<esc>Lua`)

--- a/mlua-sys/src/lua52/lualib.rs
+++ b/mlua-sys/src/lua52/lualib.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `lualib.h`.
 
-use std::os::raw::c_int;
+use std::ffi::c_int;
 
 use super::lua::lua_State;
 

--- a/mlua-sys/src/lua53/compat.rs
+++ b/mlua-sys/src/lua53/compat.rs
@@ -1,6 +1,6 @@
 //! MLua compatibility layer for Lua 5.3
 
-use std::os::raw::c_int;
+use std::ffi::c_int;
 
 use super::lua::*;
 

--- a/mlua-sys/src/lua53/lauxlib.rs
+++ b/mlua-sys/src/lua53/lauxlib.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `lauxlib.h`.
 
-use std::os::raw::{c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void};
 use std::ptr;
 
 use super::lua::{self, lua_CFunction, lua_Integer, lua_Number, lua_State};

--- a/mlua-sys/src/lua53/lua.rs
+++ b/mlua-sys/src/lua53/lua.rs
@@ -1,8 +1,8 @@
 //! Contains definitions from `lua.h`.
 
+use std::ffi::{c_char, c_double, c_int, c_uchar, c_void};
 use std::marker::{PhantomData, PhantomPinned};
 use std::mem;
-use std::os::raw::{c_char, c_double, c_int, c_uchar, c_void};
 use std::ptr;
 
 // Mark for precompiled code (`<esc>Lua`)

--- a/mlua-sys/src/lua53/lualib.rs
+++ b/mlua-sys/src/lua53/lualib.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `lualib.h`.
 
-use std::os::raw::c_int;
+use std::ffi::c_int;
 
 use super::lua::lua_State;
 

--- a/mlua-sys/src/lua54/lauxlib.rs
+++ b/mlua-sys/src/lua54/lauxlib.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `lauxlib.h`.
 
-use std::os::raw::{c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void};
 use std::ptr;
 
 use super::lua::{self, lua_CFunction, lua_Integer, lua_Number, lua_State};

--- a/mlua-sys/src/lua54/lua.rs
+++ b/mlua-sys/src/lua54/lua.rs
@@ -1,8 +1,8 @@
 //! Contains definitions from `lua.h`.
 
+use std::ffi::{c_char, c_double, c_int, c_uchar, c_ushort, c_void};
 use std::marker::{PhantomData, PhantomPinned};
 use std::mem;
-use std::os::raw::{c_char, c_double, c_int, c_uchar, c_ushort, c_void};
 use std::ptr;
 
 // Mark for precompiled code (`<esc>Lua`)

--- a/mlua-sys/src/lua54/lualib.rs
+++ b/mlua-sys/src/lua54/lualib.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `lualib.h`.
 
-use std::os::raw::c_int;
+use std::ffi::c_int;
 
 use super::lua::lua_State;
 

--- a/mlua-sys/src/luau/compat.rs
+++ b/mlua-sys/src/luau/compat.rs
@@ -3,8 +3,8 @@
 //! Based on github.com/keplerproject/lua-compat-5.3
 
 use std::ffi::CStr;
+use std::ffi::{c_char, c_int, c_void};
 use std::mem;
-use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
 
 use super::lauxlib::*;

--- a/mlua-sys/src/luau/lauxlib.rs
+++ b/mlua-sys/src/luau/lauxlib.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `lualib.h`.
 
-use std::os::raw::{c_char, c_float, c_int, c_void};
+use std::ffi::{c_char, c_float, c_int, c_void};
 use std::ptr;
 
 use super::lua::{

--- a/mlua-sys/src/luau/lua.rs
+++ b/mlua-sys/src/luau/lua.rs
@@ -1,7 +1,7 @@
 //! Contains definitions from `lua.h`.
 
+use std::ffi::{c_char, c_double, c_float, c_int, c_uint, c_void};
 use std::marker::{PhantomData, PhantomPinned};
-use std::os::raw::{c_char, c_double, c_float, c_int, c_uint, c_void};
 use std::ptr;
 
 // Option for multiple returns in 'lua_pcall' and 'lua_call'

--- a/mlua-sys/src/luau/luacode.rs
+++ b/mlua-sys/src/luau/luacode.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `luacode.h`.
 
-use std::os::raw::{c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void};
 use std::slice;
 
 #[repr(C)]

--- a/mlua-sys/src/luau/luacode.rs
+++ b/mlua-sys/src/luau/luacode.rs
@@ -2,6 +2,7 @@
 
 use std::ffi::{c_char, c_int, c_void};
 use std::slice;
+use std::vec::Vec;
 
 #[repr(C)]
 pub struct lua_CompileOptions {

--- a/mlua-sys/src/luau/luacodegen.rs
+++ b/mlua-sys/src/luau/luacodegen.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `luacodegen.h`.
 
-use std::os::raw::c_int;
+use std::ffi::c_int;
 
 use super::lua::lua_State;
 

--- a/mlua-sys/src/luau/lualib.rs
+++ b/mlua-sys/src/luau/lualib.rs
@@ -1,6 +1,6 @@
 //! Contains definitions from `lualib.h`.
 
-use std::os::raw::c_int;
+use std::ffi::c_int;
 
 use super::lua::lua_State;
 

--- a/mlua-sys/src/macros.rs
+++ b/mlua-sys/src/macros.rs
@@ -1,7 +1,6 @@
 #[allow(unused_macros)]
 macro_rules! cstr {
     ($s:expr) => {
-        concat!($s, "\0") as *const str as *const [::std::os::raw::c_char]
-            as *const ::std::os::raw::c_char
+        concat!($s, "\0") as *const str as *const [::std::ffi::c_char] as *const ::std::ffi::c_char
     };
 }

--- a/mlua_derive/src/lib.rs
+++ b/mlua_derive/src/lib.rs
@@ -59,7 +59,7 @@ pub fn lua_module(attr: TokenStream, item: TokenStream) -> TokenStream {
         #func
 
         #[no_mangle]
-        unsafe extern "C-unwind" fn #ext_entrypoint_name(state: *mut ::mlua::lua_State) -> ::std::os::raw::c_int {
+        unsafe extern "C-unwind" fn #ext_entrypoint_name(state: *mut ::mlua::lua_State) -> ::std::ffi::c_int {
             let lua = ::mlua::Lua::init_from_ptr(state);
             lua.skip_memory_check(#skip_memory_check);
             lua.entrypoint1(#func_name)

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::CString;

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -220,7 +220,7 @@ impl Compiler {
 
     /// Compiles the `source` into bytecode.
     pub fn compile(&self, source: impl AsRef<[u8]>) -> Vec<u8> {
-        use std::os::raw::c_int;
+        use std::ffi::c_int;
         use std::ptr;
 
         let vector_lib = self.vector_lib.clone();

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -3,7 +3,9 @@ use std::prelude::v1::*;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::CString;
+#[cfg(feature = "std")]
 use std::io::Result as IoResult;
+#[cfg(feature = "std")]
 use std::path::{Path, PathBuf};
 use std::string::String as StdString;
 
@@ -12,6 +14,10 @@ use crate::function::Function;
 use crate::lua::Lua;
 use crate::table::Table;
 use crate::value::{FromLuaMulti, IntoLua, IntoLuaMulti};
+
+#[cfg(not(feature = "std"))]
+/// Without `std`, `AsChunk::source()` won't do any file I/O, but may try to do UTF-8 conversion.
+pub type IoResult<T> = std::result::Result<T, std::str::Utf8Error>;
 
 /// Trait for types [loadable by Lua] and convertible to a [`Chunk`]
 ///
@@ -76,6 +82,7 @@ impl<'a> AsChunk<'_, 'a> for &'a Vec<u8> {
     }
 }
 
+#[cfg(feature = "std")]
 impl AsChunk<'_, 'static> for &Path {
     fn name(&self) -> Option<StdString> {
         Some(format!("@{}", self.display()))
@@ -86,6 +93,7 @@ impl AsChunk<'_, 'static> for &Path {
     }
 }
 
+#[cfg(feature = "std")]
 impl AsChunk<'_, 'static> for PathBuf {
     fn name(&self) -> Option<StdString> {
         Some(format!("@{}", self.display()))

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::TryInto;

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::TryInto;
+use std::ffi::c_int;
 use std::ffi::{CStr, CString};
 use std::hash::{BuildHasher, Hash};
-use std::os::raw::c_int;
 use std::string::String as StdString;
 use std::{slice, str};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::error::Error as StdError;
 use std::fmt;
 use std::io::Error as IoError;

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::cell::RefCell;
 use std::ffi::{c_int, c_void};
 use std::mem;

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
+use std::ffi::{c_int, c_void};
 use std::mem;
-use std::os::raw::{c_int, c_void};
 use std::ptr;
 use std::slice;
 
@@ -458,8 +458,8 @@ impl<'lua> Function<'lua> {
     where
         F: FnMut(CoverageInfo),
     {
+        use std::ffi::c_char;
         use std::ffi::CStr;
-        use std::os::raw::c_char;
 
         unsafe extern "C-unwind" fn callback<F: FnMut(CoverageInfo)>(
             data: *mut c_void,

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 use std::cell::UnsafeCell;
+use std::ffi::c_int;
 #[cfg(not(feature = "luau"))]
 use std::ops::{BitOr, BitOrAssign};
-use std::os::raw::c_int;
 
 use ffi::lua_Debug;
 
@@ -353,7 +353,9 @@ impl HookTriggers {
     // Returns the `count` parameter to pass to `lua_sethook`, if applicable. Otherwise, zero is
     // returned.
     pub(crate) const fn count(&self) -> c_int {
-        let Some(n) = self.every_nth_instruction else { return 0 };
+        let Some(n) = self.every_nth_instruction else {
+            return 0;
+        };
         n as c_int
     }
 }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::borrow::Cow;
 use std::cell::UnsafeCell;
 use std::ffi::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@
 // warnings at all.
 #![doc(test(attr(deny(warnings))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![no_std]
+
+extern crate no_std_compat2 as std;
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,9 @@ pub mod prelude;
 pub use ffi::{self, lua_CFunction, lua_State};
 
 pub use crate::chunk::{AsChunk, Chunk, ChunkMode};
-pub use crate::error::{Error, ErrorContext, ExternalError, ExternalResult, Result};
+pub use crate::error::{Error, ErrorContext, Result};
+#[cfg(feature = "std")]
+pub use crate::error::{ExternalError, ExternalResult};
 pub use crate::function::{Function, FunctionInfo};
 pub use crate::hook::{Debug, DebugEvent, DebugNames, DebugSource, DebugStack};
 pub use crate::lua::{GCMode, Lua, LuaOptions};

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::ops::Deref;
 use std::os::raw::{c_char, c_int, c_void};
-#[cfg(not(feature = "abort"))]
+#[cfg(feature = "panic-safety")]
 use std::panic::{catch_unwind, resume_unwind};
 use std::panic::{AssertUnwindSafe, Location};
 use std::ptr::NonNull;
@@ -39,7 +39,7 @@ use crate::util::{
     init_userdata_metatable, pop_error, push_gc_userdata, push_string, push_table, rawset_field,
     short_type_name, StackGuard, WrappedFailure,
 };
-#[cfg(not(feature = "abort"))]
+#[cfg(feature = "panic-safety")]
 use crate::util::{safe_pcall, safe_xpcall};
 use crate::value::{FromLua, FromLuaMulti, IntoLua, IntoLuaMulti, MultiValue, Nil, Value};
 
@@ -173,7 +173,7 @@ pub struct LuaOptions {
     ///
     /// [`pcall`]: https://www.lua.org/manual/5.4/manual.html#pdf-pcall
     /// [`xpcall`]: https://www.lua.org/manual/5.4/manual.html#pdf-xpcall
-    #[cfg(not(feature = "abort"))]
+    #[cfg(feature = "panic-safety")]
     pub catch_rust_panics: bool,
 
     /// Max size of thread (coroutine) object pool used to execute asynchronous functions.
@@ -199,7 +199,7 @@ impl LuaOptions {
     /// Returns a new instance of `LuaOptions` with default parameters.
     pub const fn new() -> Self {
         LuaOptions {
-            #[cfg(not(feature = "abort"))]
+            #[cfg(feature = "panic-safety")]
             catch_rust_panics: true,
             #[cfg(feature = "async")]
             thread_pool_size: 0,
@@ -210,7 +210,7 @@ impl LuaOptions {
     ///
     /// [`catch_rust_panics`]: #structfield.catch_rust_panics
     #[must_use]
-    #[cfg(not(feature = "abort"))]
+    #[cfg(feature = "panic-safety")]
     pub const fn catch_rust_panics(mut self, enabled: bool) -> Self {
         self.catch_rust_panics = enabled;
         self
@@ -390,6 +390,9 @@ impl Lua {
 
     /// Creates a new Lua state with required `libs` and `options`
     unsafe fn inner_new(libs: StdLib, options: LuaOptions) -> Lua {
+        #[cfg(not(feature = "panic-safety"))]
+        let _ = options;
+
         let mut mem_state: *mut MemoryState = Box::into_raw(Box::default());
         let mut state = ffi::lua_newstate(ALLOCATOR, mem_state as *mut c_void);
         // If state is null then switch to Lua internal allocator
@@ -419,7 +422,7 @@ impl Lua {
         );
         (*extra).libs |= libs;
 
-        #[cfg(not(feature = "abort"))]
+        #[cfg(feature = "panic-safety")]
         if !options.catch_rust_panics {
             mlua_expect!(
                 (|| -> Result<()> {
@@ -2434,7 +2437,7 @@ impl Lua {
                         ffi::lua_pop(state, 1);
                         Value::Error(err)
                     }
-                    #[cfg(not(feature = "abort"))]
+                    #[cfg(feature = "panic-safety")]
                     Some(WrappedFailure::Panic(panic)) => {
                         if let Some(panic) = panic.take() {
                             ffi::lua_pop(state, 1);
@@ -2530,7 +2533,7 @@ impl Lua {
                 match get_gc_userdata::<WrappedFailure>(state, idx, wrapped_failure_mt_ptr).as_mut()
                 {
                     Some(WrappedFailure::Error(err)) => Value::Error(err.clone()),
-                    #[cfg(not(feature = "abort"))]
+                    #[cfg(feature = "panic-safety")]
                     Some(WrappedFailure::Panic(panic)) => {
                         if let Some(panic) = panic.take() {
                             resume_unwind(panic);
@@ -3378,7 +3381,7 @@ where
     // to store a wrapped failure (error or panic) *before* we proceed.
     let prealloc_failure = PreallocatedFailure::reserve(state, extra);
 
-    #[cfg(feature = "abort")]
+    #[cfg(not(feature = "panic-safety"))]
     fn catch_unwind<F: FnOnce() -> R, R>(f: F) -> Result<R> {
         Ok(f())
     }
@@ -3411,9 +3414,9 @@ where
 
             ffi::lua_error(state)
         }
-        #[cfg(feature = "abort")]
+        #[cfg(not(feature = "panic-safety"))]
         Err(p) => unreachable!("panic = abort, but encountered {:?}", p),
-        #[cfg(not(feature = "abort"))]
+        #[cfg(feature = "panic-safety")]
         Err(p) => {
             let wrapped_panic = prealloc_failure.r#use(state, extra);
             ptr::write(wrapped_panic, WrappedFailure::Panic(Some(p)));

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::any::TypeId;
 use std::cell::{RefCell, UnsafeCell};
 use std::ffi::{c_char, c_int, c_void};

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -1,11 +1,11 @@
 use std::any::TypeId;
 use std::cell::{RefCell, UnsafeCell};
+use std::ffi::{c_char, c_int, c_void};
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::ops::Deref;
-use std::os::raw::{c_char, c_int, c_void};
 #[cfg(feature = "panic-safety")]
 use std::panic::{catch_unwind, resume_unwind};
 use std::panic::{AssertUnwindSafe, Location};

--- a/src/luau.rs
+++ b/src/luau.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::ffi::CStr;
 use std::ffi::{c_float, c_int};
 use std::string::String as StdString;

--- a/src/luau.rs
+++ b/src/luau.rs
@@ -1,5 +1,5 @@
 use std::ffi::CStr;
-use std::os::raw::{c_float, c_int};
+use std::ffi::{c_float, c_int};
 use std::string::String as StdString;
 
 use crate::chunk::ChunkMode;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,8 +10,7 @@ macro_rules! bug_msg {
 
 macro_rules! cstr {
     ($s:expr) => {
-        concat!($s, "\0") as *const str as *const [::std::os::raw::c_char]
-            as *const ::std::os::raw::c_char
+        concat!($s, "\0") as *const str as *const [::std::ffi::c_char] as *const ::std::ffi::c_char
     };
 }
 
@@ -101,7 +100,7 @@ macro_rules! protect_lua {
     };
 
     ($state:expr, $nargs:expr, $nresults:expr, fn($state_inner:ident) $code:expr) => {{
-        use ::std::os::raw::c_int;
+        use ::std::ffi::c_int;
         unsafe extern "C-unwind" fn do_call($state_inner: *mut ffi::lua_State) -> c_int {
             $code;
             let nresults = $nresults;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,5 +1,5 @@
 use std::alloc::{self, Layout};
-use std::os::raw::c_void;
+use std::ffi::c_void;
 use std::ptr;
 
 #[cfg(feature = "luau")]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::alloc::{self, Layout};
 use std::ffi::c_void;
 use std::ptr;

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::ffi::c_int;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1,6 +1,6 @@
+use std::ffi::c_int;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
-use std::os::raw::c_int;
 use std::result::Result as StdResult;
 
 use crate::error::Result;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,19 +3,21 @@
 #[doc(no_inline)]
 pub use crate::{
     AnyUserData as LuaAnyUserData, AnyUserDataExt as LuaAnyUserDataExt, Chunk as LuaChunk,
-    Error as LuaError, ErrorContext as LuaErrorContext, ExternalError as LuaExternalError,
-    ExternalResult as LuaExternalResult, FromLua, FromLuaMulti, Function as LuaFunction,
-    FunctionInfo as LuaFunctionInfo, GCMode as LuaGCMode, Integer as LuaInteger, IntoLua,
-    IntoLuaMulti, LightUserData as LuaLightUserData, Lua, LuaOptions, MetaMethod as LuaMetaMethod,
-    MultiValue as LuaMultiValue, Nil as LuaNil, Number as LuaNumber, RegistryKey as LuaRegistryKey,
-    Result as LuaResult, StdLib as LuaStdLib, String as LuaString, Table as LuaTable,
-    TableExt as LuaTableExt, TablePairs as LuaTablePairs, TableSequence as LuaTableSequence,
-    Thread as LuaThread, ThreadStatus as LuaThreadStatus, UserData as LuaUserData,
-    UserDataFields as LuaUserDataFields, UserDataMetatable as LuaUserDataMetatable,
-    UserDataMethods as LuaUserDataMethods, UserDataRef as LuaUserDataRef,
-    UserDataRefMut as LuaUserDataRefMut, UserDataRegistry as LuaUserDataRegistry,
-    Value as LuaValue,
+    Error as LuaError, ErrorContext as LuaErrorContext, FromLua, FromLuaMulti,
+    Function as LuaFunction, FunctionInfo as LuaFunctionInfo, GCMode as LuaGCMode,
+    Integer as LuaInteger, IntoLua, IntoLuaMulti, LightUserData as LuaLightUserData, Lua,
+    LuaOptions, MetaMethod as LuaMetaMethod, MultiValue as LuaMultiValue, Nil as LuaNil,
+    Number as LuaNumber, RegistryKey as LuaRegistryKey, Result as LuaResult, StdLib as LuaStdLib,
+    String as LuaString, Table as LuaTable, TableExt as LuaTableExt, TablePairs as LuaTablePairs,
+    TableSequence as LuaTableSequence, Thread as LuaThread, ThreadStatus as LuaThreadStatus,
+    UserData as LuaUserData, UserDataFields as LuaUserDataFields,
+    UserDataMetatable as LuaUserDataMetatable, UserDataMethods as LuaUserDataMethods,
+    UserDataRef as LuaUserDataRef, UserDataRefMut as LuaUserDataRefMut,
+    UserDataRegistry as LuaUserDataRegistry, Value as LuaValue,
 };
+
+#[cfg(feature = "std")]
+pub use crate::{ExternalError as LuaExternalError, ExternalResult as LuaExternalResult};
 
 #[cfg(not(feature = "luau"))]
 #[doc(no_inline)]

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::ffi::c_int;

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,8 +1,8 @@
 use std::any::Any;
 use std::cell::{Cell, RefCell};
+use std::ffi::c_int;
 use std::marker::PhantomData;
 use std::mem;
-use std::os::raw::c_int;
 
 #[cfg(feature = "serialize")]
 use serde::Serialize;
@@ -434,7 +434,9 @@ impl<'lua, 'scope> Scope<'lua, 'scope> {
                             push_table(state, 0, fields_nrec, true)?;
                         }
                         for (k, f) in registry.fields {
-                            let NonStaticMethod::Function(f) = f else { unreachable!() };
+                            let NonStaticMethod::Function(f) = f else {
+                                unreachable!()
+                            };
                             mlua_assert!(f(lua, 0)? == 1, "field function must return one value");
                             rawset_field(state, -2, &k)?;
                         }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::cell::RefCell;
 use std::convert::TryInto;
 use std::ffi::c_void;

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
-use std::os::raw::c_void;
+use std::ffi::c_void;
 use std::rc::Rc;
 use std::result::Result as StdResult;
 use std::string::String as StdString;

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,4 +1,5 @@
 //! (De)Serialization support using serde.
+use std::prelude::v1::*;
 
 use std::ffi::c_void;
 

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,6 +1,6 @@
 //! (De)Serialization support using serde.
 
-use std::os::raw::c_void;
+use std::ffi::c_void;
 
 use serde::{de::DeserializeOwned, ser::Serialize};
 

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use serde::{ser, Serialize};
 
 use super::LuaSerdeExt;

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
 use std::u32;
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::borrow::{Borrow, Cow};
 use std::ffi::c_void;
 use std::hash::{Hash, Hasher};

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,6 +1,6 @@
 use std::borrow::{Borrow, Cow};
+use std::ffi::c_void;
 use std::hash::{Hash, Hasher};
-use std::os::raw::c_void;
 use std::string::String as StdString;
 use std::{fmt, slice, str};
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
+use std::ffi::c_void;
 use std::fmt;
 use std::marker::PhantomData;
-use std::os::raw::c_void;
 
 #[cfg(feature = "serialize")]
 use {

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::collections::HashSet;
 use std::ffi::c_void;
 use std::fmt;

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,4 +1,4 @@
-use std::os::raw::c_int;
+use std::ffi::c_int;
 
 use crate::error::{Error, Result};
 #[allow(unused)]

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::ffi::c_int;
 
 use crate::error::{Error, Result};

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,8 @@
 use std::any::{Any, TypeId};
 use std::cell::{Cell, Ref, RefCell, RefMut, UnsafeCell};
+use std::ffi::{c_int, c_void};
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
-use std::os::raw::{c_int, c_void};
 use std::result::Result as StdResult;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::any::{Any, TypeId};
 use std::cell::{Cell, Ref, RefCell, RefMut, UnsafeCell};
 use std::ffi::{c_int, c_void};

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -1,11 +1,11 @@
 use std::any::{type_name, TypeId};
 use std::cell::{Ref, RefCell, RefMut};
 use std::ffi::CStr;
+use std::ffi::{c_char, c_int};
 use std::fmt;
 use std::hash::Hash;
 use std::mem;
 use std::ops::{Deref, DerefMut};
-use std::os::raw::{c_char, c_int};
 use std::string::String as StdString;
 
 #[cfg(feature = "async")]

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::any::{type_name, TypeId};
 use std::cell::{Ref, RefCell, RefMut};
 use std::ffi::CStr;

--- a/src/userdata_ext.rs
+++ b/src/userdata_ext.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use crate::error::{Error, Result};
 use crate::private::Sealed;
 use crate::userdata::{AnyUserData, MetaMethod};

--- a/src/userdata_impl.rs
+++ b/src/userdata_impl.rs
@@ -7,6 +7,7 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::ffi::c_int;
 use std::marker::PhantomData;
 use std::string::String as StdString;
+#[cfg(feature = "std")]
 use std::sync::{Arc, Mutex, RwLock};
 
 use crate::error::{Error, Result};
@@ -103,10 +104,12 @@ impl<'lua, T: 'static> UserDataRegistry<'lua, T> {
                     let ud = try_self_arg!(ud.try_borrow(), Error::UserDataBorrowError);
                     method(lua, &ud, args?)?.push_into_stack_multi(lua)
                 }
+                #[cfg(feature = "std")]
                 Some(id) if id == TypeId::of::<Arc<T>>() => {
                     let ud = try_self_arg!(get_userdata_ref::<Arc<T>>(state, index));
                     method(lua, &ud, args?)?.push_into_stack_multi(lua)
                 }
+                #[cfg(feature = "std")]
                 Some(id) if id == TypeId::of::<Arc<Mutex<T>>>() => {
                     let ud = try_self_arg!(get_userdata_ref::<Arc<Mutex<T>>>(state, index));
                     let ud = try_self_arg!(ud.try_lock(), Error::UserDataBorrowError);
@@ -119,6 +122,7 @@ impl<'lua, T: 'static> UserDataRegistry<'lua, T> {
                     let ud = try_self_arg!(ud.try_lock().ok_or(Error::UserDataBorrowError));
                     method(lua, &ud, args?)?.push_into_stack_multi(lua)
                 }
+                #[cfg(feature = "std")]
                 Some(id) if id == TypeId::of::<Arc<RwLock<T>>>() => {
                     let ud = try_self_arg!(get_userdata_ref::<Arc<RwLock<T>>>(state, index));
                     let ud = try_self_arg!(ud.try_read(), Error::UserDataBorrowError);
@@ -180,7 +184,9 @@ impl<'lua, T: 'static> UserDataRegistry<'lua, T> {
                     let mut ud = try_self_arg!(ud.try_borrow_mut(), Error::UserDataBorrowMutError);
                     method(lua, &mut ud, args?)?.push_into_stack_multi(lua)
                 }
+                #[cfg(feature = "std")]
                 Some(id) if id == TypeId::of::<Arc<T>>() => Err(Error::UserDataBorrowMutError),
+                #[cfg(feature = "std")]
                 Some(id) if id == TypeId::of::<Arc<Mutex<T>>>() => {
                     let ud = try_self_arg!(get_userdata_mut::<Arc<Mutex<T>>>(state, index));
                     let mut ud = try_self_arg!(ud.try_lock(), Error::UserDataBorrowMutError);
@@ -193,6 +199,7 @@ impl<'lua, T: 'static> UserDataRegistry<'lua, T> {
                     let mut ud = try_self_arg!(ud.try_lock().ok_or(Error::UserDataBorrowMutError));
                     method(lua, &mut ud, args?)?.push_into_stack_multi(lua)
                 }
+                #[cfg(feature = "std")]
                 Some(id) if id == TypeId::of::<Arc<RwLock<T>>>() => {
                     let ud = try_self_arg!(get_userdata_mut::<Arc<RwLock<T>>>(state, index));
                     let mut ud = try_self_arg!(ud.try_write(), Error::UserDataBorrowMutError);
@@ -785,8 +792,11 @@ lua_userdata_impl!(Rc<T>);
 #[cfg(not(feature = "send"))]
 lua_userdata_impl!(Rc<RefCell<T>>);
 
+#[cfg(feature = "std")]
 lua_userdata_impl!(Arc<T>);
+#[cfg(feature = "std")]
 lua_userdata_impl!(Arc<Mutex<T>>);
+#[cfg(feature = "std")]
 lua_userdata_impl!(Arc<RwLock<T>>);
 #[cfg(feature = "parking_lot")]
 lua_userdata_impl!(Arc<parking_lot::Mutex<T>>);

--- a/src/userdata_impl.rs
+++ b/src/userdata_impl.rs
@@ -2,8 +2,8 @@
 
 use std::any::TypeId;
 use std::cell::{Ref, RefCell, RefMut};
+use std::ffi::c_int;
 use std::marker::PhantomData;
-use std::os::raw::c_int;
 use std::string::String as StdString;
 use std::sync::{Arc, Mutex, RwLock};
 

--- a/src/userdata_impl.rs
+++ b/src/userdata_impl.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::await_holding_refcell_ref, clippy::await_holding_lock)]
 
+use std::prelude::v1::*;
+
 use std::any::TypeId;
 use std::cell::{Ref, RefCell, RefMut};
 use std::ffi::c_int;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,11 +9,19 @@ use std::mem::MaybeUninit;
 use std::panic::AssertUnwindSafe;
 #[cfg(feature = "panic-safety")]
 use std::panic::{catch_unwind, resume_unwind};
-use std::sync::Arc;
 use std::{mem, ptr, slice, str};
 
+#[cfg(not(any(feature = "std", target_has_atomic = "ptr")))]
+use std::rc::Rc as Arc;
+#[cfg(any(feature = "std", target_has_atomic = "ptr"))]
+use std::sync::Arc;
+
 use once_cell::sync::Lazy;
+#[cfg(feature = "std")]
 use rustc_hash::FxHashMap;
+#[cfg(not(feature = "std"))]
+type FxHashMap<K, V> =
+    std::collections::HashMap<K, V, core::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 use crate::error::{Error, Result};
 use crate::memory::MemoryState;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,7 +4,9 @@ use std::ffi::CStr;
 use std::fmt::Write;
 use std::mem::MaybeUninit;
 use std::os::raw::{c_char, c_int, c_void};
-use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
+use std::panic::AssertUnwindSafe;
+#[cfg(not(feature = "abort"))]
+use std::panic::{catch_unwind, resume_unwind};
 use std::sync::Arc;
 use std::{mem, ptr, slice, str};
 
@@ -201,6 +203,7 @@ pub unsafe fn pop_error(state: *mut ffi::lua_State, err_code: c_int) -> Error {
             ffi::lua_pop(state, 1);
             err.clone()
         }
+        #[cfg(not(feature = "abort"))]
         Some(WrappedFailure::Panic(panic)) => {
             if let Some(p) = panic.take() {
                 resume_unwind(p);
@@ -655,6 +658,11 @@ where
     let ud = WrappedFailure::new_userdata(state);
     ffi::lua_rotate(state, 1, 1);
 
+    #[cfg(feature = "abort")]
+    fn catch_unwind<F: FnOnce() -> R, R>(f: F) -> Result<R> {
+        Ok(f())
+    }
+
     match catch_unwind(AssertUnwindSafe(|| f(nargs))) {
         Ok(Ok(r)) => {
             ffi::lua_remove(state, 1);
@@ -680,6 +688,9 @@ where
 
             ffi::lua_error(state)
         }
+        #[cfg(feature = "abort")]
+        Err(p) => unreachable!("panic = abort, but encountered {:?}", p),
+        #[cfg(not(feature = "abort"))]
         Err(p) => {
             ffi::lua_settop(state, 1);
             ptr::write(ud, WrappedFailure::Panic(Some(p)));
@@ -730,6 +741,7 @@ pub unsafe fn error_traceback_thread(state: *mut ffi::lua_State, thread: *mut ff
 }
 
 // A variant of `pcall` that does not allow Lua to catch Rust panics from `callback_error`.
+#[cfg(not(feature = "abort"))]
 pub unsafe extern "C-unwind" fn safe_pcall(state: *mut ffi::lua_State) -> c_int {
     ffi::luaL_checkstack(state, 2, ptr::null());
 
@@ -756,6 +768,7 @@ pub unsafe extern "C-unwind" fn safe_pcall(state: *mut ffi::lua_State) -> c_int 
 }
 
 // A variant of `xpcall` that does not allow Lua to catch Rust panics from `callback_error`.
+#[cfg(not(feature = "abort"))]
 pub unsafe extern "C-unwind" fn safe_xpcall(state: *mut ffi::lua_State) -> c_int {
     unsafe extern "C-unwind" fn xpcall_msgh(state: *mut ffi::lua_State) -> c_int {
         ffi::luaL_checkstack(state, 2, ptr::null());
@@ -889,6 +902,7 @@ pub unsafe fn init_error_registry(state: *mut ffi::lua_State) -> Result<()> {
                     let _ = write!(&mut (*err_buf), "{error}");
                     Ok(err_buf)
                 }
+                #[cfg(not(feature = "abort"))]
                 Some(WrappedFailure::Panic(Some(ref panic))) => {
                     let err_buf_key = &ERROR_PRINT_BUFFER_KEY as *const u8 as *const c_void;
                     ffi::lua_rawgetp(state, ffi::LUA_REGISTRYINDEX, err_buf_key);
@@ -905,6 +919,7 @@ pub unsafe fn init_error_registry(state: *mut ffi::lua_State) -> Result<()> {
                     };
                     Ok(err_buf)
                 }
+                #[cfg(not(feature = "abort"))]
                 Some(WrappedFailure::Panic(None)) => Err(Error::PreviouslyResumedPanic),
                 _ => {
                     // I'm not sure whether this is possible to trigger without bugs in mlua?
@@ -1004,6 +1019,7 @@ pub unsafe fn init_error_registry(state: *mut ffi::lua_State) -> Result<()> {
 pub(crate) enum WrappedFailure {
     None,
     Error(Error),
+    #[cfg(not(feature = "abort"))]
     Panic(Option<Box<dyn Any + Send + 'static>>),
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,9 +1,9 @@
 use std::any::{Any, TypeId};
 use std::borrow::Cow;
 use std::ffi::CStr;
+use std::ffi::{c_char, c_int, c_void};
 use std::fmt::Write;
 use std::mem::MaybeUninit;
-use std::os::raw::{c_char, c_int, c_void};
 use std::panic::AssertUnwindSafe;
 #[cfg(feature = "panic-safety")]
 use std::panic::{catch_unwind, resume_unwind};

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::any::{Any, TypeId};
 use std::borrow::Cow;
 use std::ffi::CStr;

--- a/src/util/short_names.rs
+++ b/src/util/short_names.rs
@@ -1,6 +1,7 @@
 //! Mostly copied from [bevy_utils]
 //!
 //! [bevy_utils]: https://github.com/bevyengine/bevy/blob/main/crates/bevy_utils/src/short_names.rs
+use std::prelude::v1::*;
 
 use std::any::type_name;
 
@@ -66,6 +67,7 @@ fn collapse_type_name(string: &str) -> &str {
 mod tests {
     use super::short_type_name;
     use std::collections::HashMap;
+    use std::prelude::v1::*;
 
     #[test]
     fn tests() {

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,8 +7,12 @@ use std::ffi::{c_int, c_void};
 use std::iter::{self, FromIterator};
 use std::ops::Index;
 use std::string::String as StdString;
-use std::sync::Arc;
 use std::{fmt, mem, ptr, slice, str, vec};
+
+#[cfg(not(any(feature = "std", target_has_atomic = "ptr")))]
+use std::rc::Rc as Arc;
+#[cfg(any(feature = "std", target_has_atomic = "ptr"))]
+use std::sync::Arc;
 
 use num_traits::FromPrimitive;
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashSet;
+use std::ffi::{c_int, c_void};
 use std::iter::{self, FromIterator};
 use std::ops::Index;
-use std::os::raw::{c_int, c_void};
 use std::string::String as StdString;
 use std::sync::Arc;
 use std::{fmt, mem, ptr, slice, str, vec};

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashSet;

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -41,7 +41,9 @@ fn test_error_context() -> Result<()> {
         .context("some new context")
     })?;
     let res = func3.call::<_, ()>(()).err().unwrap();
-    let Error::CallbackError { cause, .. } = &res else { unreachable!() };
+    let Error::CallbackError { cause, .. } = &res else {
+        unreachable!()
+    };
     assert!(!res.to_string().contains("some context"));
     assert!(res.to_string().contains("some new context"));
     assert!(cause.downcast_ref::<io::Error>().is_some());

--- a/tests/function.rs
+++ b/tests/function.rs
@@ -86,7 +86,7 @@ fn test_rust_function() -> Result<()> {
 fn test_c_function() -> Result<()> {
     let lua = Lua::new();
 
-    unsafe extern "C-unwind" fn c_function(state: *mut mlua::lua_State) -> std::os::raw::c_int {
+    unsafe extern "C-unwind" fn c_function(state: *mut mlua::lua_State) -> std::ffi::c_int {
         let lua = Lua::init_from_ptr(state);
         lua.globals().set("c_function", true).unwrap();
         0

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -366,6 +366,7 @@ fn test_error() -> Result<()> {
 }
 
 #[test]
+#[cfg(not(feature = "abort"))]
 fn test_panic() -> Result<()> {
     fn make_lua(options: LuaOptions) -> Result<Lua> {
         let lua = Lua::new_with(StdLib::ALL_SAFE, options)?;

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -1,4 +1,4 @@
-use std::os::raw::c_void;
+use std::ffi::c_void;
 
 use mlua::{Function, LightUserData, Lua, Result};
 

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::os::raw::c_void;
+use std::ffi::c_void;
 use std::ptr;
 use std::string::String as StdString;
 


### PR DESCRIPTION
Dummy PR, for the purpose of tracking commits + seeing diffs.

The goal is to get this working for builds that don't provide `std`, but still provide `alloc` and `critical-section`.

~Changelog:~ (rewrote the port, see further below)

- ~I had to switch a bunch of `use` statements to import from `core` instead of `std`~
- ~I adjusted `mlua-sys` to use the `cstr::cstr!` and `libm::fabs()` rather than using `std`'s `concat!()` and floating point `f64::abs()`.~
- ~I opted out of the `std` feature flag for `mlua`'s dependencies.~
- ~Going `no_std` for `rustc-hash` took away its `HashMap` and `HashSet`, so I had to piece it together again using the `HashMap` and `HashSet` definitions from `hashbrown`, extended with `rustc-hash`'s hasher.~

Changelog:
- I introduced an `std` feature that includes `std` compilation and is included by default.
- I use type definitions from `std::ffi` instead of `std::os::raw`; the latter are not available in `core`/`no-std-compat2` (and its [docs](https://doc.rust-lang.org/std/os/raw/index.html) recommend using `core::ffi`).
- I use the [`no-std-compat2`](https://crates.io/crates/no-std-compat2) as a compatibility layer, which just redirects `use std` invocations to the appropriate modules from `core` and `alloc`. It also implements `HashMap` using `hashbrown`. This minimizes the lines of code that need to change and allows the crate to continue idiomatically using `std`.
- I use `num_traits::Float` to recover `f64::abs()` (which is not available in `#![no_std]`); that uses `libm::fabs()` under the hood.
- I redefine `FxHashMap` using `hashbrown`-provided `HashMap` (via `no-std-compat2`) and `rustc_hash::FxHasher`; the `std`-less build for `rustc_hash` lacks `FxHashMap`.
- I use `Rc` and `RefCell` in place of `Arc` and `Mutex` (both of which are missing on `thumbv6m`).
- I replace `AtomicPtr::swap()` with separate `::load()` and `::store()` (since `thumbv6m` does not have a swap instruction).
- I remove support for panic safety by making `catch_unwind()` and a nop.
- I get rid of the ability to read in `Chunk`s from `std::path::{Path, PathBuf}`.

It now currently compiles with:

```console
$ cargo build --no-default-features --features lua51,vendored --target thumbv6m-none-eabi
```

(and also works for `lua5{2,3,4}` as well).

**Note that this is not _yet_ tested on any hardware.**